### PR TITLE
consul/handler.py: Give an explicit message

### DIFF
--- a/consul/handler.py
+++ b/consul/handler.py
@@ -874,6 +874,12 @@ class Caddyfile():
     def dumps(cls, caddylist):
         out = ''
         for i, host in enumerate(caddylist):
+            if not isinstance(host, dict):
+                raise Exception(
+                    "Your CADDYFILE env is malformated, "
+                    "you may have missed a space or a bracket.\n"
+                    "current host: %r" % host
+                )
             out += ', '.join(host['keys']) + ' {\n'
             for directive in host['body']:
                 for j, diritem in enumerate(directive):
@@ -1055,6 +1061,10 @@ class TestCase(unittest.TestCase):
                 d['caddy'],
                 Caddyfile.dumps(json.loads(d['json'], strict=False)))
             print('test # {} ok'.format(i))
+
+    def test_missing_space(self):
+        with self.assertRaises(Exception):
+            Caddyfile.dumps(Caddyfile.loads('foo{\n    root /bar\n}'))
 
     def test_reversibility(self):
         for i, d in enumerate(self.data):


### PR DESCRIPTION
if a space is missing between hostname and bracket
while parsing CADDYFILE env