### PR TITLE
#10071: consul/handler.py, strip CADDYFILE env ends of lines

### DIFF
--- a/consul/handler.py
+++ b/consul/handler.py
@@ -812,6 +812,7 @@ class Caddyfile():
         lines: the remaining lines
         """
         out = []
+        line = line.strip()
         for i, c in enumerate(line):
             out = out or ['']
             if c in ('"', "'"):
@@ -1158,6 +1159,14 @@ class TestCase(unittest.TestCase):
         app = Application(self.repo_url, 'master')
         app.download()
         self.assertEqual(None, app.register_kv('node1', 'node2'))
+
+    def test_brackets_generation(self):
+        self.assertEqual(
+            Caddyfile.dumps(Caddyfile.loads(
+                'host1 {\n    dir1\n}  \nhost2 {\n    dir2\n}'
+            )),
+            'host1 {\n    dir1\n}\nhost2 {\n    dir2\n}'
+        )
 
 
 class FakeExec(object):


### PR DESCRIPTION
as the handler is parsing CADDYFILE env to add default configuration
and regenerate the config file it as some weekness. here we allow
spaces at the end of lines after a closing bracket. which was
resulting to a corrupt Caddyfile configuraiton.