### PR TITLE
#10 do not use columns in repo path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,6 @@
+Change log
+==========
+
+* Allow to bind relative path in docker-compose service, you will needs
+  to move ``~/deploy`` directory to ``/deploy`` in order to make consistency
+  tree between consul docker container and the host server

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,4 +3,5 @@ Change log
 
 * Allow to bind relative path in docker-compose service, you will needs
   to move ``~/deploy`` directory to ``/deploy`` in order to make consistency
-  tree between consul docker container and the host server
+  tree between consul docker container and the host server. (cf `issue 10
+  <https://github.com/mlfmonde/cluster/issues/10>`_)

--- a/consul/handler.py
+++ b/consul/handler.py
@@ -20,7 +20,7 @@ from subprocess import run, CalledProcessError, PIPE
 from sys import stdin, argv
 from urllib.parse import urlparse
 from uuid import uuid1
-DTFORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+DTFORMAT = "%Y-%m-%dT%H%M%S.%f"
 DEPLOY = '/deploy'
 CADDYLOGS = '/var/log'
 TEST = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - consul_docker_cfg:/home/consul/.docker
       - /var/run/docker.sock:/var/run/docker.sock
       - /run/docker/plugins:/run/docker/plugins
-      - ~/deploy:/deploy
+      - /deploy:/deploy
       - ./caddy/conf/:/consul/template/caddy/
       - ./haproxy/conf/:/consul/template/haproxy/
       - consul_ssh:/home/consul/.ssh


### PR DESCRIPTION
In fact docker and docker-compose use columns : to distinguish
path source (on the host) and target (in the docker container)
while binding volume.

So columns MUST be prohibited in path if we needs to bind
files nor directories