### PR TITLE
Haproxy to service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change log
 ==========
 
+* Add support to ``CONSUL_CHECK_URLS`` to add extra consul checks
+
+* Allow ``HAPROXY`` environment to add backends in ``http-in`` and ``https-in``
+  frontend
+
+* Add ``HAPROXY`` environment variable to manage haproxy.cfg from service
+  definition (docker-compose.yml)
+
 * Allow to bind relative path in docker-compose service, you will needs
   to move ``~/deploy`` directory to ``/deploy`` in order to make consistency
   tree between consul docker container and the host server. (cf `issue 10

--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,75 @@ through environment variables:
    You must link the container to the cluster_default network
 
 
+``HAPROXY`` can be a yaml or json format (as far python ``yaml.load`` car parse
+json) so a more exhaustive config may looks like this::
+
+        http-in:
+          backends:
+            - name: another.example.com
+              use_backend_option: "if { hdr(host) -i another.example.com }"
+              port: 80
+              peer_port: 80
+        ssh-config-name:
+          frontend:
+            mode: tcp
+            bind:
+              - "*:2222"
+            options:
+              - "test"
+              - "test2"
+          backends:
+            - name: ssh-service-wordpress2
+              port: 22
+              peer_port: 2222
+              server_option: send_proxy
+
+
+* ``http-in`` and ``https-in`` are special values to manage HTTP (80) and
+  HTTPS (443) ports. frontend configuration will be ignored, you needs to
+  write the configuration in the ``haproxy.cfg.tmpl``. Otherwhise
+  ``ssh-config-name`` will be the name of the frontend in the haproxy
+  configuration. It MUST be unique over services (different docker-compose.yml).
+
+.. note::
+
+    If a frontend name is the same over services in the same docker-compose.yml
+    frontend options, bind and backends are aggregated.
+
+* ``frontend``: define frontend configuration. Required if config name is not
+  one of ``http-in``, ``https-in``.
+
+    * ``mode`` (required): `mode or protocole <https://cbonte.github.io/
+      haproxy-dconv/1.8/configuration.html#4.2-mode>`_
+    * ``bind`` (required): refer to `haproxy bind options <https://
+      cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.1>`_
+    * ``options`` (optional): a list of valid frontend options to add to the
+      frontend. on line per item.
+* ``backends`` (required): a list of backend
+    * ``use_backend_option`` (optional, you sould provide it in case of
+      ``http-in`` or ``https-in``): options added in the frontend part to
+      properly select the current backend. Learn more on `haproxy
+      documentation <https://cbonte.github.io/haproxy-dconv/1.8/
+      configuration.html#4.2-use_backend>`_.
+    * ``port`` (required): listening service port
+    * ``peer_port`` (required): listening port by haproxy while forwarding
+      traffic to another host
+    * ``server_option``: add options to the server directive which forward
+      traffic to the service or other nodes, refer to the haproxy `server
+      and default server options <https://cbonte.github.io/haproxy-dconv/1.8/
+      configuration.html#5.2>`_.
+
+* ``CONSUL_CHECK_URLS``: `Consul can check <https://www.consul.io/docs/agent/
+  checks.html>`_ if the service is healthy. By default the handler introspect
+  your ``CADDYFILE`` environment to add checks. You can use this one to add
+  extra check or if you are using only ``HAPROXY`` config.
+
+  .. note::
+
+    If you provide a ``service.json`` it will overwrite introspected checks
+    and checks defined in ``CONSUL_CHECK_URLS``
+
+
 Local development environment
 -----------------------------
 

--- a/consul/handler.py
+++ b/consul/handler.py
@@ -488,7 +488,6 @@ class Application(object):
         caddyfiles = concat([self.caddyfile(s) for s in self.services])
         caddyfiles = [c for c in caddyfiles if c]
         urls = concat([c['keys'] for c in caddyfiles])
-        urls.extend(self.consul_extra_check_urls(self.services))
         pubkey = {  # TODO support environments as lists
             s: self.compose['services'][s].get('environment', {}
                                                ).get('PUBKEY', '')

--- a/consul/handler.py
+++ b/consul/handler.py
@@ -396,7 +396,6 @@ class Application(object):
     def haproxy(self, services):
         result = {}
         for service in services:
-            hapx = {}
             name = 'HAPROXY'
             try:
                 env = self.compose['services'][service]['environment']
@@ -412,20 +411,36 @@ class Application(object):
                 log.info('Found a %s environment variable for '
                          'service %s in the compose file of %s',
                          name, service, self.name)
-                hapx = json.loads(haproxy)
+                hapx = yaml.load(haproxy)
             except Exception as e:
                 log.warning(
                     'Invalid %s environment variable for '
                     'service %s in the compose file of %s: %s. \nCaused by '
                     'the following configuration wich will be ignored, '
-                    'make sure it\'s a valid json: ',
+                    'make sure it\'s a valid json/yaml: ',
                     name, service, self.name, str(e)
                 )
                 continue
             for key, conf in hapx.items():
                 for backend in conf['backends']:
                     backend['ct'] = self.container_name(service)
-            result.update(hapx)
+                if key in result:
+                    bind = conf.get('frontend', {}).get('bind', [])
+                    bind.extend(
+                        result[key].get('frontend', {}).get('bind', [])
+                    )
+                    if bind:
+                        result[key]['frontend']["bind"] = list(set(bind))
+
+                    options = conf.get('frontend', {}).get('options', [])
+                    options.extend(
+                        result[key].get('frontend', {}).get('options', [])
+                    )
+                    if options:
+                        result[key]['frontend']['options'] = list(set(options))
+                    result[key]['backends'].extend(conf['backends'])
+                else:
+                    result[key] = conf
         return result
 
     def register_kv(self, master, slave):
@@ -1214,7 +1229,7 @@ class TestCase(unittest.TestCase):
             'host1 {\n    dir1\n}\nhost2 {\n    dir2\n}'
         )
 
-    def test_happroxy_config(self):
+    def test_haproxy_config(self):
         app = Application(self.repo_url, 'master')
         app.download()
         self.assertEqual(
@@ -1234,6 +1249,121 @@ class TestCase(unittest.TestCase):
                 }
             },
             app.haproxy(app.services)
+        )
+
+    def test_merge_service_configs_haproxy(self):
+        app = Application(
+            'https://gitlab.example.com/hosting/FooBar2',
+            'master'
+        )
+        app.download()
+        self.maxDiff = None
+        expected = {
+            "https-in": {
+                "backends": [{
+                    "name": "an.example.com",
+                    "use_backend_option": "if { req_ssl_sni -i an.example.com"
+                                          " }",
+                    "port": "443",
+                    "peer_port": "1443",
+                    "server_option": "send_proxy",
+                    "ct": "foobar2masterdec69_wordpress_1"
+                }]
+            },
+            "http-in": {
+                "backends": [{
+                    "name": "an.example.com",
+                    "use_backend_option":
+                        " if { hdr(host) -i an.example.com }",
+                    "port": "80",
+                    "peer_port": "80",
+                    "ct": "foobar2masterdec69_wordpress_1"
+                }, {
+                    "name": "another.example.com",
+                    "use_backend_option":
+                        " if { hdr(host) -i another.example.com }",
+                    "port": "80",
+                    "peer_port": "80",
+                    "ct": "foobar2masterdec69_wordpress2_1"
+                }]
+            },
+            "other-config": {
+                "frontend": {
+                    "mode": "tcp",
+                    "bind": ["*:1111"],
+                    "options": [
+                        "option socket-stats",
+                        "tcp-request inspect-delay 5s",
+                        "tcp-request content accept "
+                        "if { req_ssl_hello_type 1 }"
+                    ]
+                },
+                "backends": [{
+                    "name": "other-config",
+                    "use_backend_option":
+                        "if { req_ssl_sni -i other.example.com }",
+                    "port": "11",
+                    "peer_port": "1111",
+                    "ct": "foobar2masterdec69_wordpress_1"
+                }]
+            },
+            "ssh-config-name": {
+                "frontend": {
+                    "mode": "tcp",
+                    "bind": ["*:2222", "*:4444"],
+                    "options": [
+                        "option socket-stats",
+                        "tcp-request inspect-delay 5s",
+                        "tcp-request content accept "
+                        "if { req_ssl_hello_type 1 }",
+                        "test",
+                        "test2"
+                    ]
+                },
+                "backends": [{
+                        "name": "ssh-service-wordpress2",
+                        "use_backend_option": "",
+                        "port": "22",
+                        "peer_port": "2222",
+                        "server_option": "send_proxy",
+                        "ct": "foobar2masterdec69_wordpress2_1"
+                    }, {
+                        "name": "ssh-service",
+                        "use_backend_option": "",
+                        "port": "22",
+                        "peer_port": "2222",
+                        "ct": "foobar2masterdec69_sshservice_1"
+                    }, {
+                        "name": "ssh-service2",
+                        "use_backend_option": "",
+                        "port": "22",
+                        "peer_port": "4444",
+                        "ct": "foobar2masterdec69_sshservice2_1"
+                    },
+                ]
+            }
+        }
+        got = app.haproxy(app.services)
+        self.assertEqual(len(got), len(expected))
+        self.assertEqual(
+            len(got['ssh-config-name']),
+            len(expected['ssh-config-name'])
+        )
+        self.assertEqual(
+            len(got['ssh-config-name']['backends']),
+            len(expected['ssh-config-name']['backends'])
+        )
+        self.assertEqual(
+            sorted(got['ssh-config-name']['frontend']['bind']),
+            sorted(expected['ssh-config-name']['frontend']['bind'])
+        )
+        self.assertEqual(
+            sorted(got['ssh-config-name']['frontend']['options']),
+            sorted(expected['ssh-config-name']['frontend']['options'])
+        )
+        self.assertEqual(
+            len(got['http-in']),
+            len(expected['http-in'])
         )
 
 

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -22,7 +22,7 @@ frontend https-in
     tcp-request content accept if { req_ssl_hello_type 1 }
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttps" | contains $domain }}{{ else }}    use_backend https-{{ $domain }} if { req_ssl_sni -i {{ $domain }} }
 {{ scratch.MapSet "fronthttps" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ or ($backend.name) $backend.ct }} {{ or ($backend.use_backend_option) "" }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ or (index $backend "name") $backend.ct }} {{ $or (index $backend "use_backend_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttps" | contains $domain }}{{ else }}
@@ -31,9 +31,9 @@ backend https-{{ $domain }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:443{{ else }}{{ $d.ip }}:1443{{ end }} send-proxy
 {{ scratch.MapSet "backhttps" $domain $domain }}{{ end }}{{ end }}
 {{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
-backend https-{{ or ($backend.name) $backend.ct }}
+backend https-{{ or (index $backend "name") $backend.ct }}
     mode http
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or ($backend.server_option) "" }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or (index $backend "server_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 frontend http-in
@@ -42,7 +42,7 @@ frontend http-in
     option socket-stats
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttp" | contains $domain }}{{ else }}    use_backend http-{{ $domain }} if { hdr(host) -i {{ $domain }} }
 {{ scratch.MapSet "fronthttp" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend http-{{ or ($backend.name) $backend.ct }} {{ or ($backend.use_backend_option) "" }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend http-{{ or (index $backend "name") $backend.ct }} {{ $or (index $backend "use_backend_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttp" | contains $domain }}{{ else }}
@@ -51,9 +51,9 @@ backend http-{{ $domain }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:80{{ else }}{{ $d.ip }}:80{{ end }}
 {{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}
 {{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
-backend http-{{ or ($backend.name) $backend.ct }}
+backend http-{{ or (index $backend "name") $backend.ct }}
     mode http
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or ($backend.server_option) "" }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or (index $backend "server_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}
@@ -61,9 +61,9 @@ frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
     {{ range $option := $conf.frontend.options }}{{ $option }}{{ end }}
     {{ range $bind := $conf.frontend.bind }}bind {{ $bind }}{{ end }}
-    {{ range $backend := $conf.backends }}use_backend backend-{{ or ($backend.name) $backend.ct }} {{ or ($backend.use_backend_option) "" }}{{ end }}
+    {{ range $backend := $conf.backends }}use_backend backend-{{ or (index $backend "name") $backend.ct }} {{ $or (index $backend "use_backend_option") "" }}{{ end }}
 {{ range $backend := $conf.backends }}
-backend backend-{{ or ($backend.name) $backend.ct }}
+backend backend-{{ or (index $backend "name") $backend.ct }}
     mode {{ $conf.frontend.mode }}
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or ($backend.server_option) "" }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or (index $backend "server_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -22,7 +22,7 @@ frontend https-in
     tcp-request content accept if { req_ssl_hello_type 1 }
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttps" | contains $domain }}{{ else }}    use_backend https-{{ $domain }} if { req_ssl_sni -i {{ $domain }} }
 {{ scratch.MapSet "fronthttps" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ $backend.name }} {{ $backend.use_backend_option }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ or ($backend.name) $backend.ct }} {{ or ($backend.use_backend_option) "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttps" | contains $domain }}{{ else }}
@@ -31,7 +31,9 @@ backend https-{{ $domain }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:443{{ else }}{{ $d.ip }}:1443{{ end }} send-proxy
 {{ scratch.MapSet "backhttps" $domain $domain }}{{ end }}{{ end }}
 {{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ $backend.server_option }}
+backend https-{{ or ($backend.name) $backend.ct }}
+    mode http
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or ($backend.server_option) "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 frontend http-in
@@ -40,7 +42,7 @@ frontend http-in
     option socket-stats
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttp" | contains $domain }}{{ else }}    use_backend http-{{ $domain }} if { hdr(host) -i {{ $domain }} }
 {{ scratch.MapSet "fronthttp" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ $backend.name }} {{ $backend.use_backend_option }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend http-{{ or ($backend.name) $backend.ct }} {{ or ($backend.use_backend_option) "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttp" | contains $domain }}{{ else }}
@@ -49,7 +51,9 @@ backend http-{{ $domain }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:80{{ else }}{{ $d.ip }}:80{{ end }}
 {{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}
 {{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ $backend.server_option }}
+backend http-{{ or ($backend.name) $backend.ct }}
+    mode http
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or ($backend.server_option) "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}
@@ -57,9 +61,9 @@ frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
     {{ range $option := $conf.frontend.options }}{{ $option }}{{ end }}
     {{ range $bind := $conf.frontend.bind }}bind {{ $bind }}{{ end }}
-    {{ range $backend := $conf.backends }}use_backend backend-{{ $backend.name }} {{ $backend.use_backend_option }}{{ end }}
+    {{ range $backend := $conf.backends }}use_backend backend-{{ or ($backend.name) $backend.ct }} {{ or ($backend.use_backend_option) "" }}{{ end }}
 {{ range $backend := $conf.backends }}
-backend backend-{{ $backend.name }}
+backend backend-{{ or ($backend.name) $backend.ct }}
     mode {{ $conf.frontend.mode }}
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ $backend.server_option }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or ($backend.server_option) "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -40,7 +40,7 @@ backend http-{{ $domain }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:80{{ else }}{{ $d.ip }}:80{{ end }}
 {{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}{{ end }}
 
-{{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $confname, $conf := $d.haproxy }}
+{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}
 frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
     {{ range $bind := $conf.frontend.bind }}bind {{ $bind }}{{ end }}
@@ -49,4 +49,4 @@ frontend front-{{ $confname }}
 backend backend-{{ $backend.name }}
     mode {{ $conf.frontend.mode }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }}
-{{ end }}{{ end }}{{ end }}
+{{ end }}{{ end }}{{ end }}{{ end }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -50,7 +50,7 @@ backend http-{{ $domain }}
     mode http
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:80{{ else }}{{ $d.ip }}:80{{ end }}
 {{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}
 backend http-{{ or (index $backend "name") $backend.ct }}
     mode http
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or (index $backend "server_option") "" }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -40,35 +40,15 @@ backend http-{{ $domain }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:80{{ else }}{{ $d.ip }}:80{{ end }}
 {{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}{{ end }}
 
-{{ if and (keyExists "app/cluster_gitlab_prod.2e066") (not (keyExists "maintenance/cluster_gitlab_prod.2e066")) }}
-frontend git-prod-ssh-in
-    mode tcp
-    bind *:2222
-    use_backend ssh-prod-git
-
-backend ssh-prod-git
-    mode tcp
-{{ with $v := key "app/cluster_gitlab_prod.2e066" | parseJSON }}    server {{ $v.master }} {{ if eq $v.master (env "HOSTNAME") }}{{ $v.ct.web }}:22{{ else }}{{ $v.ip }}:2222{{ end }}{{ end }}
-{{ end }}
-
-{{ if and (keyExists "app/cluster_gitlab_master.2e066") (not (keyExists "maintenance/cluster_gitlab_master.2e066")) }}
-frontend git-ppd-ssh-in
-    mode tcp
-    bind *:2525
-    use_backend ssh-ppd-git
-
-backend ssh-ppd-git
-    mode tcp
-{{ with $v := key "app/cluster_gitlab_master.2e066" | parseJSON }}    server {{ $v.master }} {{ if eq $v.master (env "HOSTNAME") }}{{ $v.ct.web }}:22{{ else }}{{ $v.ip }}:2525{{ end }}{{ end }}
-{{ end }}
-
-{{ if and (keyExists "app/cluster_gitlab_dev.2e066") (not (keyExists "maintenance/cluster_gitlab_dev.2e066")) }}
-frontend git-dev-ssh-in
-    mode tcp
-    bind *:2626
-    use_backend ssh-dev-git
-
-backend ssh-dev-git
-    mode tcp
-{{ with $v := key "app/cluster_gitlab_dev.2e066" | parseJSON }}    server {{ $v.master }} {{ if eq $v.master (env "HOSTNAME") }}{{ $v.ct.web }}:22{{ else }}{{ $v.ip }}:2626{{ end }}{{ end }}
-{{ end }}
+{{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $confname, $conf := $d.haproxy }}
+frontend front-{{ $confname }}
+    mode {{ $conf.frontend.mode }}
+    {{ range $bind := $conf.bind }}bind {{ $bind }}
+    {{ end }}
+    {{ range $backend := $conf.backends }}use_backend backend-{{ $backend.name }} {{ $backend.use_backend_option }}
+    {{ end }}
+{{ range $backend := $conf.backends }}
+backend backend-{{ $backend.name }}
+    mode {{ $conf.frontend.mode }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }}
+{{ end }}{{ end }}{{ end }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -43,10 +43,11 @@ backend http-{{ $domain }}
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}
 frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
+    {{ range $option := $conf.frontend.options }}{{ $option }}{{ end }}
     {{ range $bind := $conf.frontend.bind }}bind {{ $bind }}{{ end }}
     {{ range $backend := $conf.backends }}use_backend backend-{{ $backend.name }} {{ $backend.use_backend_option }}{{ end }}
 {{ range $backend := $conf.backends }}
 backend backend-{{ $backend.name }}
     mode {{ $conf.frontend.mode }}
-    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ $backend.server_option }}
 {{ end }}{{ end }}{{ end }}{{ end }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -56,7 +56,7 @@ backend http-{{ or (index $backend "name") $backend.ct }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or (index $backend "server_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
-{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}
+{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if not (or (eq $confname "http-in") (eq $confname "https-in")) }}
 frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
     {{ range $option := $conf.frontend.options }}{{ $option }}{{ end }}
@@ -66,4 +66,4 @@ frontend front-{{ $confname }}
 backend backend-{{ or (index $backend "name") $backend.ct }}
     mode {{ $conf.frontend.mode }}
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ or (index $backend "server_option") "" }}
-{{ end }}{{ end }}{{ end }}{{ end }}
+{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -20,25 +20,37 @@ frontend https-in
     option socket-stats
     tcp-request inspect-delay 5s
     tcp-request content accept if { req_ssl_hello_type 1 }
-{{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttps" | contains $domain }}{{ else }}    use_backend https-{{ $domain }} if { req_ssl_sni -i {{ $domain }} }
-{{ scratch.MapSet "fronthttps" $domain $domain }}{{ end }}{{ end }}{{ end }}
-{{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttps" | contains $domain }}{{ else }}
+{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttps" | contains $domain }}{{ else }}    use_backend https-{{ $domain }} if { req_ssl_sni -i {{ $domain }} }
+{{ scratch.MapSet "fronthttps" $domain $domain }}{{ end }}{{ end }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ $backend.name }} {{ $backend.use_backend_option }}
+{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
+
+{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttps" | contains $domain }}{{ else }}
 backend https-{{ $domain }}
     mode tcp
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:443{{ else }}{{ $d.ip }}:1443{{ end }} send-proxy
-{{ scratch.MapSet "backhttps" $domain $domain }}{{ end }}{{ end }}{{ end }}
+{{ scratch.MapSet "backhttps" $domain $domain }}{{ end }}{{ end }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ $backend.server_option }}
+{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 frontend http-in
     mode http
     bind *:80
     option socket-stats
-{{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttp" | contains $domain }}{{ else }}    use_backend http-{{ $domain }} if { hdr(host) -i {{ $domain }} }
-{{ scratch.MapSet "fronthttp" $domain $domain }}{{ end }}{{ end }}{{ end }}
-{{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttp" | contains $domain }}{{ else }}
+{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttp" | contains $domain }}{{ else }}    use_backend http-{{ $domain }} if { hdr(host) -i {{ $domain }} }
+{{ scratch.MapSet "fronthttp" $domain $domain }}{{ end }}{{ end }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ $backend.name }} {{ $backend.use_backend_option }}
+{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
+
+{{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttp" | contains $domain }}{{ else }}
 backend http-{{ $domain }}
     mode http
     server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}caddy:80{{ else }}{{ $d.ip }}:80{{ end }}
-{{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}{{ end }}
+{{ scratch.MapSet "backhttp" $domain $domain }}{{ end }}{{ end }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}
+    server {{ $d.master }} {{ if eq $d.master (env "HOSTNAME") }}{{ $backend.ct }}:{{ $backend.port }}{{ else }}{{ $d.ip }}:{{ $backend.peer_port }}{{ end }} {{ $backend.server_option }}
+{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}
 frontend front-{{ $confname }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -22,7 +22,7 @@ frontend https-in
     tcp-request content accept if { req_ssl_hello_type 1 }
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttps" | contains $domain }}{{ else }}    use_backend https-{{ $domain }} if { req_ssl_sni -i {{ $domain }} }
 {{ scratch.MapSet "fronthttps" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ or (index $backend "name") $backend.ct }} {{ $or (index $backend "use_backend_option") "" }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "https-in" }}{{ range $backend := $conf.backends }}    use_backend https-{{ or (index $backend "name") $backend.ct }} {{ or (index $backend "use_backend_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttps" | contains $domain }}{{ else }}
@@ -42,7 +42,7 @@ frontend http-in
     option socket-stats
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "fronthttp" | contains $domain }}{{ else }}    use_backend http-{{ $domain }} if { hdr(host) -i {{ $domain }} }
 {{ scratch.MapSet "fronthttp" $domain $domain }}{{ end }}{{ end }}
-{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend http-{{ or (index $backend "name") $backend.ct }} {{ $or (index $backend "use_backend_option") "" }}
+{{ if not (keyExists (print "maintenance/" $k)) }}{{ range $confname, $conf := $d.haproxy }}{{ if eq $confname "http-in" }}{{ range $backend := $conf.backends }}    use_backend http-{{ or (index $backend "name") $backend.ct }} {{ or (index $backend "use_backend_option") "" }}
 {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
 
 {{ range $apps }}{{ $k := .Key }}{{ $d := .Value | parseJSON }}{{ range $domain := $d.domains }}{{ if scratch.MapValues "backhttp" | contains $domain }}{{ else }}
@@ -61,7 +61,7 @@ frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
     {{ range $option := $conf.frontend.options }}{{ $option }}{{ end }}
     {{ range $bind := $conf.frontend.bind }}bind {{ $bind }}{{ end }}
-    {{ range $backend := $conf.backends }}use_backend backend-{{ or (index $backend "name") $backend.ct }} {{ $or (index $backend "use_backend_option") "" }}{{ end }}
+    {{ range $backend := $conf.backends }}use_backend backend-{{ or (index $backend "name") $backend.ct }} {{ or (index $backend "use_backend_option") "" }}{{ end }}
 {{ range $backend := $conf.backends }}
 backend backend-{{ or (index $backend "name") $backend.ct }}
     mode {{ $conf.frontend.mode }}

--- a/haproxy/conf/haproxy.cfg.ctmpl
+++ b/haproxy/conf/haproxy.cfg.ctmpl
@@ -43,10 +43,8 @@ backend http-{{ $domain }}
 {{ range $apps }}{{ $d := .Value | parseJSON }}{{ range $confname, $conf := $d.haproxy }}
 frontend front-{{ $confname }}
     mode {{ $conf.frontend.mode }}
-    {{ range $bind := $conf.bind }}bind {{ $bind }}
-    {{ end }}
-    {{ range $backend := $conf.backends }}use_backend backend-{{ $backend.name }} {{ $backend.use_backend_option }}
-    {{ end }}
+    {{ range $bind := $conf.frontend.bind }}bind {{ $bind }}{{ end }}
+    {{ range $backend := $conf.backends }}use_backend backend-{{ $backend.name }} {{ $backend.use_backend_option }}{{ end }}
 {{ range $backend := $conf.backends }}
 backend backend-{{ $backend.name }}
     mode {{ $conf.frontend.mode }}

--- a/testapp/FooBar.yml
+++ b/testapp/FooBar.yml
@@ -44,6 +44,25 @@ services:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: "passwd"
+  sshservice:
+    image: panubo/sshd
+    environment:
+      HAPROXY: '{
+          "ssh-config-name": {
+            "frontend": {
+              "mode": "tcp",
+              "bind": ["*:2222"]
+            },
+            "backends": [{
+              "name": "ssh-service",
+              "use_backend_option": "",
+              "port": "22",
+              "peer_port": "2222"
+            }]
+          }
+        }'
+    networks:
+      - cluster_default
 
 volumes:
   wwwdata:

--- a/testapp/FooBar2.yml
+++ b/testapp/FooBar2.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   wordpress:
     environment:
+      CONSUL_CHECK_URLS: '["https://an.example.com", "http://an.example.com"]'
       HAPROXY: '{
           "https-in": {
             "backends": [{
@@ -55,6 +56,8 @@ services:
         https://www.test.example.com {
             redir https://test.example.com
         }
+      CONSUL_CHECK_URLS: |
+        - http://another.example.com
       HAPROXY: |
         http-in:
           backends:

--- a/testapp/FooBar2.yml
+++ b/testapp/FooBar2.yml
@@ -1,0 +1,151 @@
+version: '2'
+services:
+  wordpress:
+    environment:
+      HAPROXY: '{
+          "https-in": {
+            "backends": [{
+              "name": "an.example.com",
+              "use_backend_option": "if { req_ssl_sni -i an.example.com }",
+              "port": "443",
+              "peer_port": "1443",
+              "server_option": "send_proxy"
+            }]
+          },
+          "http-in": {
+            "backends": [{
+              "name": "an.example.com",
+              "use_backend_option": " if { hdr(host) -i an.example.com }",
+              "port": "80",
+              "peer_port": "80"
+            }]
+          },
+          "other-config": {
+            "frontend": {
+              "mode": "tcp",
+              "bind": ["*:1111"],
+              "options": [
+                "option socket-stats",
+                "tcp-request inspect-delay 5s",
+                "tcp-request content accept if { req_ssl_hello_type 1 }"
+              ]
+            },
+            "backends": [{
+              "name": "other-config",
+              "use_backend_option": "if { req_ssl_sni -i other.example.com }",
+              "port": "11",
+              "peer_port": "1111"
+            }]
+          }
+        }'
+      PUBKEYS: ssh-rsa 123456 test@example
+    build: wordpress
+    restart: unless-stopped
+    volumes:
+      - wwwdata:/var/www/html
+      - socket:/var/run/mysqld/
+    networks:
+      - cluster_default
+  wordpress2:
+    environment:
+      CADDYFILE: |
+        https://test.example.com {
+            proxy / http://$CONTAINER:80
+        }
+        https://www.test.example.com {
+            redir https://test.example.com
+        }
+      HAPROXY: |
+        http-in:
+          backends:
+            - name: another.example.com
+              use_backend_option: "if { hdr(host) -i another.example.com }"
+              port: 80
+              peer_port: 80
+        ssh-config-name:
+          frontend:
+            mode: tcp
+            bind:
+              - "*:2222"
+            options:
+              - "test"
+              - "test2"
+          backends:
+            - name: ssh-service-wordpress2
+              port: 22
+              peer_port: 2222
+              server_option: send_proxy
+    build: wordpress
+    restart: unless-stopped
+    volumes:
+      - wwwdata:/var/www/html
+      - socket:/var/run/mysqld/
+    networks:
+      - cluster_default
+  mariadb:
+    image: mariadb:10
+    restart: always
+    volumes:
+      - dbdata:/var/lib/mysql
+      - socket:/var/run/mysqld/
+    environment:
+      MYSQL_ROOT_PASSWORD: "rootpasswd"
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: "passwd"
+  sshservice:
+    image: panubo/sshd
+    environment:
+      HAPROXY: '{
+          "ssh-config-name": {
+            "frontend": {
+              "mode": "tcp",
+              "bind": ["*:2222"],
+              "options": [
+                "option socket-stats",
+                "tcp-request inspect-delay 5s"
+              ]
+            },
+            "backends": [{
+              "name": "ssh-service",
+              "use_backend_option": "",
+              "port": "22",
+              "peer_port": "2222"
+            }]
+          }
+        }'
+    networks:
+      - cluster_default
+  sshservice2:
+    image: panubo/sshd
+    environment:
+      HAPROXY: '{
+          "ssh-config-name": {
+            "frontend": {
+              "mode": "tcp",
+              "bind": ["*:4444"],
+              "options": [
+                "tcp-request inspect-delay 5s",
+                "tcp-request content accept if { req_ssl_hello_type 1 }"
+              ]
+            },
+            "backends": [{
+              "name": "ssh-service2",
+              "port": "22",
+              "peer_port": "4444"
+            }]
+          }
+        }'
+    networks:
+      - cluster_default
+
+volumes:
+  wwwdata:
+    driver: btrfs
+  dbdata:
+    driver: btrfs
+  socket:
+
+networks:
+  cluster_default:
+    external: true


### PR DESCRIPTION
Goals of this PR are:
- allow to config new haproxy configuration from service (for service like ldap / git using ssh / ...)
- In some case we don't want to use caddy server for http/https but direct traffic from haproxy to the service.

this was tested against mlfmonde/cluster_lab#5