### PR TITLE
consul/handler: add non migrable label volume support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Change log
 ==========
 
+* Add support to non migrable volumes
+
 * Add support to ``CONSUL_CHECK_URLS`` to add extra consul checks
 
 * Allow ``HAPROXY`` environment to add backends in ``http-in`` and ``https-in``

--- a/README.rst
+++ b/README.rst
@@ -422,6 +422,35 @@ and / or:
   traffics to your swarm services without the needs to use an other proxy to
   your services.
 
+Non migrable volumes
+--------------------
+
+You may wan't to manage volumes that are entierly related to one environement
+so those data are not restored while using migrate to move data between apps.
+
+In order to define a volume "non migrable" you have to add a label on your
+target application:
+
+```bash
+[...]
+volumes:
+  config:
+    driver: anybox/buttervolume:latest
+    labels:
+      - com.github.mlfmonde.cluster.nonmigrable=True
+  dbdata:
+    driver: anybox/buttervolume:latest
+  socket:
+```
+
+> **Note**: You needs to move the target app from nodes to take that parameter
+> in consideration.
+
+> **Note**: You could do the same by using different name to your dedicated
+> volume environment as only commons volume name are restored to the target
+> app.
+
+
 Post migrate script
 -------------------
 

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
     && pip install docker-compose==${DOCKERCOMPOSE} \
     && pip3 install pyyaml==3.12 \
     && pip3 install urllib3==1.22 \
+    && pip3 install docker \
     && git clone https://github.com/anybox/buttervolume \
     && cd buttervolume \
     && git checkout $BUTTERVOLUME \

--- a/consul/handler.py
+++ b/consul/handler.py
@@ -701,7 +701,7 @@ class Volume(object):
     @property
     def migrable_volume(self):
         dc = DockerClient(base_url=DOCKER_BASE_URL)
-        non_migrable = dc.volumes.get(self.name).attrs.get('Labelse', {}).get(
+        non_migrable = dc.volumes.get(self.name).attrs.get('Labels', {}).get(
             LABEL_NON_MIGRABLE_VOLUME, 'false'
         )
         return not non_migrable.lower() in ['true', '1']


### PR DESCRIPTION
this allow to declare a target as a non migrable volume to avoid to restore
data from source app while using migrate event