### PR TITLE
in some case docker-py lib return None for Labels

### DIFF
--- a/consul/consul_watcher_deployer/handler.py
+++ b/consul/consul_watcher_deployer/handler.py
@@ -688,10 +688,16 @@ class Volume(object):
         log.info(u'Sending snapshot: {}'.format(snapshot))
         do("buttervolume send {} {}".format(target, snapshot))
 
+    def get_docker_client(self):
+        return DockerClient(base_url=DOCKER_BASE_URL)
+
     @property
     def migrable_volume(self):
-        dc = DockerClient(base_url=DOCKER_BASE_URL)
-        non_migrable = dc.volumes.get(self.name).attrs.get('Labels', {}).get(
+        dc = self.get_docker_client()
+        labels = dc.volumes.get(self.name).attrs.get('Labels', {})
+        if not labels:
+            labels = {}
+        non_migrable = labels.get(
             LABEL_NON_MIGRABLE_VOLUME, 'false'
         )
         return not non_migrable.lower() in ['true', '1']

--- a/consul/consul_watcher_deployer/tests/test_volumes.py
+++ b/consul/consul_watcher_deployer/tests/test_volumes.py
@@ -1,9 +1,50 @@
+from consul_watcher_deployer.handler import Volume, LABEL_NON_MIGRABLE_VOLUME
+from unittest.mock import Mock
 from unittest import TestCase
-from consul_watcher_deployer.handler import Volume
 
 
 class TestVolumes(TestCase):
-
     def test_volume(self):
         vol = Volume('test')
         self.assertEqual('test', vol.name)
+
+    def test_non_migrable(self):
+        vol = Volume('test')
+        vol.get_docker_client = Mock(return_value=Mock(
+                volumes={
+                    'test': Mock(
+                        attrs={'Labels': {LABEL_NON_MIGRABLE_VOLUME: "tRue"}}
+                    )
+                }
+            )
+        )
+        self.assertFalse(vol.migrable_volume)
+
+        vol.get_docker_client = Mock(return_value=Mock(
+                volumes={
+                    'test': Mock(
+                        attrs={'Labels': {LABEL_NON_MIGRABLE_VOLUME: "false"}}
+                    )
+                }
+            )
+        )
+        self.assertTrue(vol.migrable_volume)
+
+        vol.get_docker_client = Mock(return_value=Mock(
+                volumes={
+                    'test': Mock(
+                        attrs={'Labels': {"test": "fake"}}
+                    )
+                }
+            )
+        )
+
+        vol.get_docker_client = Mock(return_value=Mock(
+                volumes={
+                    'test': Mock(
+                        attrs={'Labels': None}
+                    )
+                }
+            )
+        )
+        self.assertTrue(vol.migrable_volume)


### PR DESCRIPTION

instead of do not set the key which makes restoring volume failing.

I guess that depends of the version